### PR TITLE
Reviews and Appeals - Minor Content changes

### DIFF
--- a/app/views/1-19/dynamic/change-core-result-appeal-2021.html
+++ b/app/views/1-19/dynamic/change-core-result-appeal-2021.html
@@ -44,7 +44,7 @@ Change assessment entry - Manage T Level results - GOV.UK
                 Core <br>(code)
               </dt>
               <dd class="govuk-summary-list__value">
-                {{ data['core'] }}
+                Design, Surveying and Planning <br>(60358300)
               </dd>
             </div>
             <div class="govuk-summary-list__row">

--- a/app/views/1-19/dynamic/core-put-on-appeal-2021.html
+++ b/app/views/1-19/dynamic/core-put-on-appeal-2021.html
@@ -47,7 +47,7 @@ Appeal grade - Manage T Level results - GOV.UK
               Core <br>(code)
             </dt>
             <dd class="govuk-summary-list__value">
-              {{ data['core'] }}
+              Design, Surveying and Planning <br>(60358300)
             </dd>
           </div>
           <div class="govuk-summary-list__row">

--- a/app/views/1-19/dynamic/core-take-off-appeal-2021.html
+++ b/app/views/1-19/dynamic/core-take-off-appeal-2021.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Add a new learner - status of Industry placement - Manage T Level results - GOV.UK
+Add outcome of appeal - Manage T Level results - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}
@@ -45,7 +45,7 @@ Add a new learner - status of Industry placement - Manage T Level results - GOV.
                 Core <br>(code)
               </dt>
               <dd class="govuk-summary-list__value">
-                {{ data['core'] }}
+                Design, Surveying and Planning <br>(60358300)
               </dd>
             </div>
             <div class="govuk-summary-list__row">

--- a/app/views/1-19/dynamic/learner-withdrawn.html
+++ b/app/views/1-19/dynamic/learner-withdrawn.html
@@ -66,7 +66,7 @@ Learner has been withdrawn - Manage T Level results - GOV.UK
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
-                  T level
+                  T Level
                 </dt>
                 <dd class="govuk-summary-list__value">
                   {{ data['tlevelTitle'] }}

--- a/app/views/1-19/dynamic/search-learner.html
+++ b/app/views/1-19/dynamic/search-learner.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Search for a learner page - Manage T Level results - GOV.UK
+Search for a learner  - Manage T Level results - GOV.UK
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/includes/reviews-appeals/record-entry-full-results-2021.html
+++ b/app/views/includes/reviews-appeals/record-entry-full-results-2021.html
@@ -41,7 +41,7 @@
     
               {% if data['newcoreOnHold2021'] === "appealed"  %}
                 <a class="govuk-link" href="core-take-off-appeal-2021">
-                  Update
+                  Update <span class="govuk-visually-hidden"> grade</span>
                 </a>
       
               {% elseif data['newcoreOnHold2021'] === "final" %}
@@ -52,7 +52,7 @@
               {% else %}
               
                 <a class="govuk-link" href="core-put-on-appeal-2021">
-                  Update
+                  Update <span class="govuk-visually-hidden"> grade</span>
                 </a>
               
               {% endif %}


### PR DESCRIPTION
Changes as a result of refinement:
- Fixed 'T level' to "T Level" on learner withdrawn page
- Added line break where core (code) is shown in the appeals journey